### PR TITLE
botに雑談機能を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *~
 __pycache__
 rita0702py
+.env
 slackbot_settings.py
 /static
 .DS_Store

--- a/plugins/my_slackbot.py
+++ b/plugins/my_slackbot.py
@@ -3,6 +3,8 @@ import random
 import csv
 import requests
 import json
+import pya3rt
+import slackbot_settings
 
 from slackbot.bot import Bot
 from slackbot.bot import respond_to
@@ -94,6 +96,15 @@ def weather(message):
     message.send('今日の天気は' + forecasts_telop + 'です！')
     message.send(text)
     message.send('お出かけするの？気をつけていってらっしゃい！')
+
+
+@default_reply()
+def send_message(message):
+    apikey = slackbot_settings.A3RT_AP
+    client = pya3rt.TalkClient(apikey)
+    api_response = client.talk(message.body['text'])
+    reply_message = api_response['results'][0]['reply']
+    message.reply(reply_message)
 
 # オウム返し
 # @respond_to('(.*)')


### PR DESCRIPTION
# What
A3RTのtalkapiを導入
python専用のライブラリとしてpya3rtが用意されているので、併せて導入
会話内容をapiを運営してサーバーにpost、返信内容をjson形式で獲得、出力する仕組み
apikeyに関してはpython-dotenvを導入して、envファイルで管理する形を取った

 # Why
slackbot機能充実のため